### PR TITLE
[SFML3] Joypad fix

### DIFF
--- a/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
+++ b/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
@@ -1292,10 +1292,10 @@ JoystickCaps JoystickImpl::getCapabilities() const
     {
         caps.axes[Joystick::Axis::X]    = true;
         caps.axes[Joystick::Axis::Y]    = true;
-        caps.axes[Joystick::Axis::Z]    = false;
+        caps.axes[Joystick::Axis::Z]    = true;
         caps.axes[Joystick::Axis::R]    = true;
         caps.axes[Joystick::Axis::U]    = true;
-        caps.axes[Joystick::Axis::V]    = false;
+        caps.axes[Joystick::Axis::V]    = true;
         caps.axes[Joystick::Axis::PovX] = true;
         caps.axes[Joystick::Axis::PovY] = true;
     }
@@ -1350,8 +1350,10 @@ JoystickState JoystickImpl::update()
     {
         state.axes[Joystick::Axis::X]    = static_cast<float>(gamepadEvent.axis[0] * 100.0);
         state.axes[Joystick::Axis::Y]    = static_cast<float>(gamepadEvent.axis[1] * 100.0);
-        state.axes[Joystick::Axis::R]    = static_cast<float>(gamepadEvent.axis[2] * 100.0);
-        state.axes[Joystick::Axis::U]    = static_cast<float>(gamepadEvent.axis[3] * 100.0);
+        state.axes[Joystick::Axis::U]    = static_cast<float>(gamepadEvent.axis[2] * 100.0);
+        state.axes[Joystick::Axis::V]    = static_cast<float>(gamepadEvent.axis[3] * 100.0);
+        state.axes[Joystick::Axis::Z]    = static_cast<float>(gamepadEvent.axis[4] * 100.0);
+        state.axes[Joystick::Axis::R]    = static_cast<float>(gamepadEvent.axis[5] * 100.0);
         state.axes[Joystick::Axis::PovX] = static_cast<float>((gamepadEvent.analogButton[15] - gamepadEvent.analogButton[14]) * 100.0);
         state.axes[Joystick::Axis::PovY] = static_cast<float>((gamepadEvent.analogButton[13] - gamepadEvent.analogButton[12]) * 100.0);
         state.buttons[12] = false;

--- a/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
+++ b/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
@@ -1354,10 +1354,10 @@ JoystickState JoystickImpl::update()
         state.axes[Joystick::Axis::U]    = static_cast<float>(gamepadEvent.axis[3] * 100.0);
         state.axes[Joystick::Axis::PovX] = static_cast<float>((gamepadEvent.analogButton[15] - gamepadEvent.analogButton[14]) * 100.0);
         state.axes[Joystick::Axis::PovY] = static_cast<float>((gamepadEvent.analogButton[13] - gamepadEvent.analogButton[12]) * 100.0);
-        gamepadEvent.digitalButton[12]   = false;
-        gamepadEvent.digitalButton[13]   = false;
-        gamepadEvent.digitalButton[14]   = false;
-        gamepadEvent.digitalButton[15]   = false;
+        state.buttons[12] = false;
+        state.buttons[13] = false;
+        state.buttons[14] = false;
+        state.buttons[15] = false;
     }
     state.connected = gamepadEvent.connected;
 

--- a/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
+++ b/src/SFML/Window/Emscripten/WindowImplEmscripten.cpp
@@ -222,6 +222,16 @@ namespace
 
     void updatePluggedList()
     {
+        if (emscripten_sample_gamepad_data() != EMSCRIPTEN_RESULT_SUCCESS)
+        {
+            sf::err() << "Failed to sample data of gamepads" << std::endl;
+            for (int i = 0; i < static_cast<int>(sf::Joystick::Count); ++i)
+            {
+                joysticksConnected[i] = false;
+            }
+            return;
+        }
+
         int numJoysticks = emscripten_get_num_gamepads();
 
         if (numJoysticks == EMSCRIPTEN_RESULT_NOT_SUPPORTED)
@@ -1205,6 +1215,12 @@ bool JoystickImpl::open(unsigned int index)
 {
     if (!isConnected(index))
         return false;
+    if (emscripten_sample_gamepad_data() != EMSCRIPTEN_RESULT_SUCCESS)
+    {
+        sf::err() << "Failed to sample data of gamepads" << std::endl;
+        joysticksConnected[index] = false;
+        return false;
+    }
 
     int numJoysticks = emscripten_get_num_gamepads();
 
@@ -1250,6 +1266,13 @@ JoystickCaps JoystickImpl::getCapabilities() const
 {
     JoystickCaps caps;
 
+    if (emscripten_sample_gamepad_data() != EMSCRIPTEN_RESULT_SUCCESS)
+    {
+        sf::err() << "Failed to sample data of gamepads" << std::endl;
+        joysticksConnected[m_index] = false;
+        return caps;
+    }
+
     EmscriptenGamepadEvent gamepadEvent;
     if (emscripten_get_gamepad_status(static_cast<int>(m_index), &gamepadEvent) != EMSCRIPTEN_RESULT_SUCCESS)
     {
@@ -1273,8 +1296,8 @@ JoystickCaps JoystickImpl::getCapabilities() const
         caps.axes[Joystick::Axis::R]    = true;
         caps.axes[Joystick::Axis::U]    = true;
         caps.axes[Joystick::Axis::V]    = false;
-        caps.axes[Joystick::Axis::PovX] = false;
-        caps.axes[Joystick::Axis::PovY] = false;
+        caps.axes[Joystick::Axis::PovX] = true;
+        caps.axes[Joystick::Axis::PovY] = true;
     }
     else
     {
@@ -1303,6 +1326,12 @@ Joystick::Identification JoystickImpl::getIdentification() const
 JoystickState JoystickImpl::update()
 {
     JoystickState state;
+    if (emscripten_sample_gamepad_data() != EMSCRIPTEN_RESULT_SUCCESS)
+    {
+        sf::err() << "Failed to sample data of gamepads" << std::endl;
+        joysticksConnected[m_index] = false;
+        return state;
+    }
 
     EmscriptenGamepadEvent gamepadEvent;
     if (emscripten_get_gamepad_status(static_cast<int>(m_index), &gamepadEvent) != EMSCRIPTEN_RESULT_SUCCESS)
@@ -1319,11 +1348,18 @@ JoystickState JoystickImpl::update()
 
     if (std::strcmp(gamepadEvent.mapping, "standard") == 0)
     {
-        state.axes[Joystick::Axis::X] = static_cast<float>(gamepadEvent.axis[0] * 100.0);
-        state.axes[Joystick::Axis::Y] = static_cast<float>(gamepadEvent.axis[1] * 100.0);
-        state.axes[Joystick::Axis::R] = static_cast<float>(gamepadEvent.axis[2] * 100.0);
-        state.axes[Joystick::Axis::U] = static_cast<float>(gamepadEvent.axis[3] * 100.0);
+        state.axes[Joystick::Axis::X]    = static_cast<float>(gamepadEvent.axis[0] * 100.0);
+        state.axes[Joystick::Axis::Y]    = static_cast<float>(gamepadEvent.axis[1] * 100.0);
+        state.axes[Joystick::Axis::R]    = static_cast<float>(gamepadEvent.axis[2] * 100.0);
+        state.axes[Joystick::Axis::U]    = static_cast<float>(gamepadEvent.axis[3] * 100.0);
+        state.axes[Joystick::Axis::PovX] = static_cast<float>((gamepadEvent.analogButton[15] - gamepadEvent.analogButton[14]) * 100.0);
+        state.axes[Joystick::Axis::PovY] = static_cast<float>((gamepadEvent.analogButton[13] - gamepadEvent.analogButton[12]) * 100.0);
+        gamepadEvent.digitalButton[12]   = false;
+        gamepadEvent.digitalButton[13]   = false;
+        gamepadEvent.digitalButton[14]   = false;
+        gamepadEvent.digitalButton[15]   = false;
     }
+    state.connected = gamepadEvent.connected;
 
     return state;
 }


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

This PR fixes issues related to the gamepad support (at least on Linux). Some calls to `emscripten_get_gamepad_status` have been added before calls to `emscripten_get_num_gamepads` and `emscripten_get_gamepad_status` which is needed according to the [documentation](https://emscripten.org/docs/api_reference/html5.h.html#c.emscripten_sample_gamepad_data).
Also:
- DPad has been mapped to axes PovX and PovY (like on Windows and Linux), instead of buttons 12 to 15.
- The second joystick is mapped to axes U and V (for X, Y) instead of of R and U (like on Windows and Linux)
- The triggers are mapped to axes Z and R (like on Windows and Linux). On chromium though, it's still mapped to button 6 and 7. On firefox it's sent to the axes array in slots 4 and 5 but on Chromium it's apparently sent to the button array on slots 6 and 7.


## Tasks

-   [x] Tested on Linux (Firefox and Chromium)
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Compile the program below, and observe the events in the console.
Before these changes, it failed to get the state on all controllers.

```cpp
#include <iostream>
#include <SFML/Graphics.hpp>

int main()
{
	sf::RenderWindow win{sf::VideoMode{sf::Vector2u{640, 480}}, "test"};

	while (win.isOpen()) {
		while (auto event = win.pollEvent()) {
			if (event->is<sf::Event::Closed>())
				win.close();
			else if (auto connect = event->getIf<sf::Event::JoystickConnected>())
				std::cout << "New gamepad connect with id " << connect->joystickId << std::endl;
			else if (auto disconnect = event->getIf<sf::Event::JoystickDisconnected>())
				std::cout << "New gamepad disconnect with id " << disconnect->joystickId << std::endl;
			else if (auto move = event->getIf<sf::Event::JoystickMoved>())
				std::cout << "Gamepad id " << move->joystickId << " moved " << move->position << " on axis " << static_cast<int>(move->axis) << std::endl;
			else if (auto press = event->getIf<sf::Event::JoystickButtonPressed>())
				std::cout << "Gamepad id " << press->joystickId << " press " << press->button << std::endl;
			else if (auto release = event->getIf<sf::Event::JoystickButtonReleased>())
				std::cout << "Gamepad id " << release->joystickId << " release " << release->button << std::endl;
		}
		win.clear(sf::Color::White);
		win.display();
	}
}
```
